### PR TITLE
Travis CI integration: lint only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 # install dependencies
 install:
   - sudo apt-get update
-  - sudo apt-get install curl unzip
+  - sudo apt-get install -y curl unzip
   # protobuf 3.3.0
   - curl -L https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip -o protoc-3.3.0.zip
   - unzip protoc-3.3.0.zip -d $HOME/protoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ install:
 
 # run main process
 script:
-  # generate C++ source code
-  - $HOME/protoc/bin/protoc *.proto --cpp_out=.
   # check .proto files for style violations
   - $HOME/protoc/bin/protoc --lint_out=. *.proto
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# https://docs.travis-ci.com/user/languages/go/
+language: go
+
+# golang version to use
+go:
+- 1.8.x
+
+# install dependencies
+install:
+  - sudo apt-get update
+  - sudo apt-get install curl unzip
+  # protobuf 3.3.0
+  - curl -L https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip -o protoc-3.3.0.zip
+  - unzip protoc-3.3.0.zip -d $HOME/protoc
+  # linter for .proto files
+  - go get github.com/ckaznocha/protoc-gen-lint
+
+# run main process
+script:
+  # generate C++ source code
+  - $HOME/protoc/bin/protoc *.proto --cpp_out=.
+  # check .proto files for style violations
+  - $HOME/protoc/bin/protoc --lint_out=. *.proto
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ install:
 
 # run main process
 script:
-  # check .proto files for style violations
+  # lint checking for all .proto files
   - $HOME/protoc/bin/protoc --lint_out=. *.proto
   

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # IoP Message Protocol
 
+[![Lint Status](https://img.shields.io/travis/Internet-of-People/message-protocol/master.svg?style=flat-square&label=lint)](https://travis-ci.org/Internet-of-People/message-protocol)
+
 The protocol for interaction with and between [Profile Servers](https://github.com/Fermat-ORG/iop-profile-server) is defined and documented in Google Protobuf v3 [Profile Server Protocol](IopProfileServer.proto) file. 
 
 The protocol for interaction with and between [Location Based Network Servers](https://github.com/Fermat-ORG/iop-location-based-network) is defined and documented in Google Protobuf v3 [Location Based Network Protocol](IopLocNet.proto) file. 
 
 The status of the tests can be found in [TESTS](TESTS.md) file. 
-


### PR DESCRIPTION
Add Travis CI conf and badge for linting purpose only. 
Only linting is needed because other projects generate code in their own language based on it.

Currents builds are failing because of style violations. Check here in order to fix the issues: https://travis-ci.org/Internet-of-People/message-protocol/builds/260403144#L569