### PR TITLE
Enable GetNodeInfo and GetRandomNodes on more interfaces

### DIFF
--- a/IopLocNet.proto
+++ b/IopLocNet.proto
@@ -174,6 +174,8 @@ message LocalServiceRequest {
     // the server is supposed to keep the connection alive and notify the client
     // about changes in its neigbhourhood by sending the following request to the client.
     NeighbourhoodChangedNotificationRequest neighbourhood_changed = 4;
+
+    GetNodeInfoRequest get_node_info = 5;
   }
 }
 
@@ -186,6 +188,8 @@ message LocalServiceResponse {
 
     // For each neigbhourhood change notification, the client must send this response as an acknowledgement.
     NeighbourhoodChangedNotificationResponse neighbourhood_updated = 4;
+
+    GetNodeInfoResponse get_node_info = 5;
   }
 }
 
@@ -318,6 +322,7 @@ message ClientRequest {
     GetNeighbourNodesByDistanceClientRequest get_neighbour_nodes = 2;
     GetClosestNodesByDistanceRequest get_closest_nodes = 3;
     ExploreNetworkNodesByDistanceRequest explore_nodes = 4;
+    GetRandomNodesRequest get_random_nodes = 5;
   }
 }
 
@@ -327,6 +332,7 @@ message ClientResponse {
     GetNeighbourNodesByDistanceResponse get_neighbour_nodes = 2;
     GetClosestNodesByDistanceResponse get_closest_nodes = 3;
     ExploreNetworkNodesByDistanceResponse explore_nodes = 4;
+    GetRandomNodesResponse get_random_nodes = 5;
   }
 }
 


### PR DESCRIPTION
GetNodeInfo is enabled for local services to get detected IP address, GPS position or other services on the host.
GetRandomNodes can be used by a crawler client to implement breadth-first graph exploration, just like nodes bootstrapping their own map.